### PR TITLE
🤖 Bot API 7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.24.0
+
+- 🤖 Bot API 7.9
+- Added new methods
+- Published Televerse Documentation website (https://televerse.xooniverse.com)
+
 # 1.23.1
 
 - Exposed couple of more properties in Context

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Pub Version](https://img.shields.io/pub/v/televerse?color=blue&logo=blue)](https://pub.dev/packages/televerse)
 ![GitHub](https://img.shields.io/github/license/xooniverse/televerse?color=green)
-![](https://shields.io/badge/Latest-Bot%20API%207.8-blue)
+![](https://shields.io/badge/Latest-Bot%20API%207.9-blue)
 
 <a href="https://telegram.me/TeleverseDart">
     <img src="https://img.shields.io/badge/Telegram%2F@TeleverseDart-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white"/>
@@ -13,7 +13,7 @@
 
 ---
 
-🤖 `Bot API version: Bot API 7.8 (July 31, 2024)`
+🤖 `Bot API version: Bot API 7.9 (August 14, 2024)`
 
 Televerse is a powerful, easy-to-use, and highly customizable Telegram bot
 framework built with Dart programming language. It provides a complete and
@@ -23,14 +23,13 @@ public interface, making it easy for developers to write strictly typed code.
 
 ## 🔥 What's latest?
 
-### 🤖 Bot API 7.8
+### 🤖 Bot API 7.9
 
-(🗓️ July 31, 2024)
+(🗓️ August 14, 2024)
 
-Simply, this change brings support for ability to manage pinned messages on behalf of a Business. 
-Much more updates on Mini apps.
+In a nutshell, this update brigngs support for channel subscription, and support for Paid Media across all chats.
 
-Checkout [changelog](https://core.telegram.org/bots/api#july-31-2024) for more
+Checkout [changelog](https://core.telegram.org/bots/api-changelog#august-14-2024) for more
 details! 🚀
 
 ### 🎉 Support for Custom Contexts!

--- a/lib/src/telegram/models/chat_member_member.dart
+++ b/lib/src/telegram/models/chat_member_member.dart
@@ -10,9 +10,13 @@ class ChatMemberMember implements ChatMember {
   @override
   final User user;
 
+  /// Optional. Date when the user's subscription will expire; Unix time
+  final int? untilDate;
+
   /// Creates a new [ChatMemberMember] object.
   const ChatMemberMember({
     required this.user,
+    this.untilDate,
   });
 
   /// Converts a [ChatMemberMember] to a [Map] for JSON encoding.
@@ -21,13 +25,15 @@ class ChatMemberMember implements ChatMember {
     return {
       'status': status.value,
       'user': user.toJson(),
-    };
+      'until_date': untilDate,
+    }..removeWhere(_nullFilter);
   }
 
   /// Creates a new [ChatMemberMember] object from json.
   factory ChatMemberMember.fromJson(Map<String, dynamic> json) {
     return ChatMemberMember(
       user: User.fromJson(json['user']),
+      untilDate: json['until_date'],
     );
   }
 

--- a/lib/src/telegram/models/models.dart
+++ b/lib/src/telegram/models/models.dart
@@ -268,3 +268,6 @@ part 'transaction_partner_telegram_ads.dart';
 
 // Bot API 7.7
 part 'refunded_payment.dart';
+
+// Bot API 7.9
+part 'reaction_type_paid.dart';

--- a/lib/src/telegram/models/reaction_type_paid.dart
+++ b/lib/src/telegram/models/reaction_type_paid.dart
@@ -1,0 +1,19 @@
+part of 'models.dart';
+
+/// The reaction is paid.
+class ReactionTypePaid implements ReactionType {
+  /// Type of the reaction, always “custom”
+  @override
+  ReactionTypeType get type => ReactionTypeType.paid;
+
+  /// Constructs the
+  const ReactionTypePaid();
+
+  /// Converts the object into a JSON parsable Map
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      "type": type.value,
+    };
+  }
+}

--- a/lib/src/telegram/models/transaction_partner_user.dart
+++ b/lib/src/telegram/models/transaction_partner_user.dart
@@ -11,10 +11,14 @@ class TransactionPartnerUser extends TransactionPartner {
   /// Bot-specified invoice payload.
   final String? invoicePayload;
 
+  /// Optional. Information about the paid media bought by the user
+  final List<PaidMedia>? paidMedia;
+
   /// Constructs a [TransactionPartnerUser] object.
   const TransactionPartnerUser({
     required this.user,
     this.invoicePayload,
+    this.paidMedia,
   });
 
   /// Creates a [TransactionPartnerUser] object from JSON.
@@ -22,6 +26,13 @@ class TransactionPartnerUser extends TransactionPartner {
     return TransactionPartnerUser(
       user: User.fromJson(json['user']),
       invoicePayload: json['invoice_payload'],
+      paidMedia: json['paid_media'] != null
+          ? List<PaidMedia>.from(
+              (json['paid_media'] as List).map(
+                (e) => PaidMedia.fromJson(e),
+              ),
+            )
+          : null,
     );
   }
 
@@ -32,6 +43,7 @@ class TransactionPartnerUser extends TransactionPartner {
       'type': type.toJson(),
       'user': user.toJson(),
       'invoice_payload': invoicePayload,
+      'paid_media': paidMedia?.map((e) => e.toJson()).toList(),
     }..removeWhere(_nullFilter);
   }
 }

--- a/lib/src/televerse/api/raw_api.dart
+++ b/lib/src/televerse/api/raw_api.dart
@@ -3983,6 +3983,7 @@ class RawAPI {
     bool? protectContent,
     ReplyParameters? replyParameters,
     ReplyMarkup? replyMarkup,
+    String? businessConnectionId,
   }) async {
     final params = {
       "chat_id": chatId.id,
@@ -3995,6 +3996,7 @@ class RawAPI {
       "protect_content": protectContent,
       "reply_parameters": replyParameters?.toJson(),
       "reply_markup": replyMarkup?.toJson(),
+      "business_connection_id": businessConnectionId,
     };
 
     List<_MultipartHelper> helpers = [];
@@ -4016,5 +4018,47 @@ class RawAPI {
     );
 
     return Message.fromJson(response);
+  }
+
+  /// Use this method to create a subscription invite link for a channel chat. The bot must have the can_invite_users administrator rights. The link can be edited using the method editChatSubscriptionInviteLink or revoked using the method revokeChatInviteLink. Returns the new invite link as a ChatInviteLink object.
+  Future<ChatInviteLink> createChatSubscriptionInviteLink({
+    required ID chatId,
+    String? name,
+    required int subscriptionPeriod,
+    required int subscriptionPrice,
+  }) async {
+    final params = {
+      "chat_id": chatId.id,
+      "name": name,
+      "subscription_period": subscriptionPeriod,
+      "subscription_price": subscriptionPrice,
+    };
+
+    final response = await _makeApiJsonCall(
+      APIMethod.createChatSubscriptionInviteLink,
+      payload: Payload(params),
+    );
+
+    return ChatInviteLink.fromJson(response);
+  }
+
+  /// Use this method to edit a subscription invite link created by the bot. The bot must have the can_invite_users administrator rights. Returns the edited invite link as a ChatInviteLink object.
+  Future<ChatInviteLink> editChatSubscriptionInviteLink({
+    required ID chatId,
+    required String inviteLink,
+    String? name,
+  }) async {
+    final params = {
+      "chat_id": chatId.id,
+      "name": name,
+      "invite_link": inviteLink,
+    };
+
+    final response = await _makeApiJsonCall(
+      APIMethod.editChatSubscriptionInviteLink,
+      payload: Payload(params),
+    );
+
+    return ChatInviteLink.fromJson(response);
   }
 }

--- a/lib/src/types/methods.dart
+++ b/lib/src/types/methods.dart
@@ -379,6 +379,12 @@ enum APIMethod {
 
   /// Sends paid media
   sendPaidMedia._("sendPaidMedia"),
+
+  /// Use this method to create a subscription invite link for a channel chat
+  createChatSubscriptionInviteLink._("createChatSubscriptionInviteLink"),
+
+  /// Use this method to edit a subscription invite link created by the bot.
+  editChatSubscriptionInviteLink._("editChatSubscriptionInviteLink"),
   ;
 
   /// The name of the method.

--- a/lib/src/types/reaction_type_emoji_type.dart
+++ b/lib/src/types/reaction_type_emoji_type.dart
@@ -7,6 +7,9 @@ enum ReactionTypeType {
 
   /// Represents a custom emoji.
   customEmoji._("custom_emoji"),
+
+  /// Paid reaction
+  paid._("paid"),
   ;
 
   /// The inner value of this enum entry.
@@ -22,6 +25,8 @@ enum ReactionTypeType {
         return emoji;
       case "custom_emoji":
         return customEmoji;
+      case "paid":
+        return paid;
       default:
         throw TeleverseException(
           "Unknown value: $value",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
-description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.8!
-version: 1.23.1
+description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.9!
+version: 1.24.0
 homepage: https://televerse.xooniverse.com
 repository: https://github.com/xooniverse/televerse
 topics:


### PR DESCRIPTION
- Added support for [Super Channels](https://telegram.org/blog/superchannels-star-reactions-subscriptions#super-channels), allowing received channel messages to have users or other channels as their senders.
- Added the ability to send paid media to any chat.
- Added the parameter business_connection_id to the method [sendPaidMedia](https://core.telegram.org/bots/api#sendpaidmedia), allowing bots to send paid media on behalf of a business account.
- Added the field paid_media to the class [TransactionPartnerUser](https://core.telegram.org/bots/api#transactionpartneruser) for transactions involving paid media.
- Added the method [createChatSubscriptionInviteLink](https://core.telegram.org/bots/api#createchatsubscriptioninvitelink), allowing bots to create subscription invite links.
- Added the method [editChatSubscriptionInviteLink](https://core.telegram.org/bots/api#editchatsubscriptioninvitelink), allowing bots to edit the name of subscription invite links.
- Added the field until_date to the class [ChatMemberMember](https://core.telegram.org/bots/api#chatmembermember) for members with an active subscription.
- Added support for paid reactions and the class [ReactionTypePaid](https://core.telegram.org/bots/api#reactiontypepaid).