### PR TITLE
Televerse v1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.26.0
+
+- [⚠️ Breaking | Plugins] Updated the `Transformer` class
+- Made the `payload` parameter for the `Transformer.transform` method optional-positional argument.
+- Added `RawAPI.call` method for independently calling the Telegram Bot API methods.
+
 # 1.25.0
 
 - 🤖 Bot API 7.10

--- a/lib/src/televerse/middlewares/transformer.dart
+++ b/lib/src/televerse/middlewares/transformer.dart
@@ -82,9 +82,9 @@ abstract interface class Transformer implements MiddlewareBase {
   /// actual API method with the modified payload.
   Future<Map<String, dynamic>> transform(
     APICaller call,
-    APIMethod method,
-    Payload payload,
-  );
+    APIMethod method, [
+    Payload? payload,
+  ]);
 
   /// Constructs a `Transformer` instance.
   const Transformer();

--- a/lib/src/televerse/middlewares/types.dart
+++ b/lib/src/televerse/middlewares/types.dart
@@ -26,6 +26,6 @@ typedef NextFunction = FutureOr<void> Function();
 /// - `Future<Map<String, dynamic>>`: A future that completes with the result
 ///   of the API call.
 typedef APICaller = Future<Map<String, dynamic>> Function(
-  APIMethod method,
-  Payload payload,
-);
+  APIMethod method, [
+  Payload? payload,
+]);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.10!
-version: 1.25.0
+version: 1.26.0
 homepage: https://televerse.xooniverse.com
 repository: https://github.com/xooniverse/televerse
 topics:


### PR DESCRIPTION
# 1.26.0

- [⚠️ Breaking | Plugins] Updated the `Transformer` class
- Made the `payload` parameter for the `Transformer.transform` method optional-positional argument.
- Added `RawAPI.call` method for independently calling the Telegram Bot API methods.
