### PR TITLE
Televerse v1.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.26.2
+
+- Added way too many internal changes.
+- Added separate method for `RawAPI` construction in `Bot`
+- `RawAPI` instance will be created along with `Bot` instance.
+- 🐞 Not having above caused transformers to not work. So obviously, fixed that.
+- Added more `Context` helper methods.
+- (Internal) `Bot._api` is now non-nullable.
+- (Internal) Properties `_loggerOptions`, `_baseURL`, and `_scheme` has been removed from `Bot`. They now solely belong to `RawAPI`.
+- (Internal) Expensive calls are cached in `Context`, such as `chat`, `msg` are now cached for better performance in recurring access.
+
 # 1.26.1
 
 - Fix [#294](https://github.com/xooniverse/televerse/issues/294).

--- a/lib/src/televerse/api/raw_api.dart
+++ b/lib/src/televerse/api/raw_api.dart
@@ -259,9 +259,10 @@ class RawAPI {
   /// multiple transformers into a single API caller function, which processes
   /// the payload through each transformer in sequence before making the API call.
   APICaller _combineTransformer(APICaller prev, Transformer transformer) {
-    return (method, [payload]) async {
-      return await transformer.transform(prev, method, payload);
-    };
+    apply(APIMethod method, [Payload? payload]) async =>
+        await transformer.transform(prev, method, payload);
+
+    return apply;
   }
 
   /// Independent API Caller.

--- a/lib/src/televerse/context/context.dart
+++ b/lib/src/televerse/context/context.dart
@@ -276,6 +276,16 @@ class Context {
         msg?.videoChatParticipantsInvited != null ||
         msg?.webAppData != null;
   }
+
+  /// Whether the incoming context has an inline query
+  bool hasInlineQuery() {
+    return update.inlineQuery != null;
+  }
+
+  /// Whether the incoming context has a callback query
+  bool hasCallbackQuery() {
+    return update.inlineQuery != null;
+  }
 }
 
 /// Base handler

--- a/lib/src/televerse/context/context.dart
+++ b/lib/src/televerse/context/context.dart
@@ -70,23 +70,56 @@ class Context {
     return msg?.text?.clean.split(' ').sublist(1) ?? [];
   }
 
+  /// (Internal) Arbitary message getter
+  ///
+  /// Populated when `msg` is first accessed.
+  Message? __msg;
+
   /// The thread id
   int? _threadId([int? id]) {
     bool isInTopic = msg?.isTopicMessage ?? false;
     return id ?? (isInTopic ? msg?.messageThreadId : null);
   }
 
+  /// (Internal) Chat Instance.
+  ///
+  /// Will be populated when `ctx.chat` is first accessed.
+  Chat? _chat;
+
   /// A shorthand getter for the [Chat] instance from the update.
   ///
   /// This can be any of `msg.chat` or `myChatMember.chat` or `chatMember.chat` or `chatJoinRequest.chat` or `messageReaction.chat` or `messageReactionCount.chat` or `chatBoost.chat` or `removedChatBoost.chat`.
-  Chat? get chat => update.chat;
+  Chat? get chat {
+    if (_chat != null) {
+      return _chat!;
+    }
+    _chat = update.chat;
+    return _chat;
+  }
+
+  /// (Internal) The user isntance from the udpate.
+  ///
+  /// Populated when `from` is first accessed.
+  User? _from;
 
   /// A shorthand getter for the [User] instance from the update.
-  User? get from => update.from;
+  User? get from {
+    if (_from != null) return _from;
+    _from = update.from;
+    return _from;
+  }
+
+  /// (Internal) The File ID.
+  ///
+  /// Populated when the `fileId` is initially accessed.
+  String? __fileId;
 
   /// Internal getter for the file id
   String? get _fileId {
-    return msg?.photo?.last.fileId ??
+    if (__fileId != null) {
+      return __fileId;
+    }
+    __fileId = msg?.photo?.last.fileId ??
         msg?.animation?.fileId ??
         msg?.audio?.fileId ??
         msg?.document?.fileId ??
@@ -94,6 +127,7 @@ class Context {
         msg?.videoNote?.fileId ??
         msg?.voice?.fileId ??
         msg?.sticker?.fileId;
+    return __fileId;
   }
 
   /// The File ID if the incoming message contains a File of any kind.
@@ -106,21 +140,37 @@ class Context {
     return chat?.id;
   }
 
+  /// (Internal) Message ID.
+  ///
+  /// Populated when the `messageId` is first accessed.
+  int? __msgId;
+
   /// The message id for internal use
   int? get _msgId {
-    return msg?.messageId ??
+    if (__msgId != null) return __msgId;
+
+    __msgId = msg?.messageId ??
         messageReaction?.messageId ??
         messageReactionCount?.messageId ??
         callbackQuery?.message?.messageId;
+    return __msgId;
   }
 
   /// The Message ID of the incoming message.
   int? get messageId => _msgId;
 
+  /// (Internal) Inline Message ID
+  ///
+  /// Populated when `inlineMessageId` is first accessed.
+  String? __inlineMsgId;
+
   /// Internal getter for inline message id
   String? get _inlineMsgId {
-    return callbackQuery?.inlineMessageId ??
-        chosenInlineResult?.inlineMessageId;
+    if (__inlineMsgId != null) return __inlineMsgId;
+
+    __inlineMsgId =
+        callbackQuery?.inlineMessageId ?? chosenInlineResult?.inlineMessageId;
+    return __inlineMsgId;
   }
 
   /// Inline Message ID from the incoming update.

--- a/lib/src/televerse/context/properties.dart
+++ b/lib/src/televerse/context/properties.dart
@@ -5,7 +5,11 @@ extension ContextUpdateMerger on Context {
   /// This is a shorthand getter for the [Message] recieved in the current context
   ///
   /// This can either be `Message` or `Channel Post` or `Edited Message` or `Edited Channel Post` or `Callback Query Message`.
-  Message? get msg => update.msg;
+  Message? get msg {
+    if (__msg != null) return __msg;
+    __msg = update.msg;
+    return __msg;
+  }
 
   /// The incoming message.
   Message? get message => update.message;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.10!
-version: 1.26.1
+version: 1.26.2
 homepage: https://televerse.xooniverse.com
 repository: https://github.com/xooniverse/televerse
 topics:


### PR DESCRIPTION
# 1.26.2

- Added way too many internal changes.
- Added separate method for `RawAPI` construction in `Bot`
- `RawAPI` instance will be created along with `Bot` instance.
- 🐞 Not having above caused transformers to not work. So obviously, fixed that.
- Added more `Context` helper methods.
- (Internal) `Bot._api` is now non-nullable.
- (Internal) Properties `_loggerOptions`, `_baseURL`, and `_scheme` has been removed from `Bot`. They now solely belong to `RawAPI`.
- (Internal) Expensive calls are cached in `Context`, such as `chat`, `msg` are now cached for better performance in recurring access.
