### PR TITLE
Check `X-Telegram-Bot-Api-Secret-Token` in Webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.26.6
+
+- Check `Webhook.secretToken` with the header `X-Telegram-Bot-Api-Secret-Token` before processing the incoming webhook update.
+
 # 1.26.5
 
 - Fixed in `ReactionTypeCustomEmoji.customEmojiId`

--- a/lib/src/televerse/fetch/webhook.dart
+++ b/lib/src/televerse/fetch/webhook.dart
@@ -258,6 +258,7 @@ class Webhook extends Fetcher {
 
   /// Handles incoming HTTP requests.
   Future<void> _handleRequest(io.HttpRequest request) async {
+    const secretTokenHeader = "X-Telegram-Bot-Api-Secret-Token";
     final Map<String, dynamic> error = {
       'ok': false,
       'error_code': 404,
@@ -272,6 +273,14 @@ class Webhook extends Fetcher {
     if (request.method == "GET") {
       error["description"] = "GET Requests are not supported";
       error["error_code"] = 418;
+      _sendResponse(request, error["error_code"], error);
+      return;
+    }
+
+    if (secretToken != null &&
+        request.headers.value(secretTokenHeader) != secretToken) {
+      error["description"] = "Unauthorized request";
+      error["error_code"] = 401;
       _sendResponse(request, error["error_code"], error);
       return;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.10!
-version: 1.26.5
+version: 1.26.6
 homepage: https://televerse.xooniverse.com
 repository: https://github.com/xooniverse/televerse
 topics:


### PR DESCRIPTION
Check `Webhook.secretToken` with the header `X-Telegram-Bot-Api-Secret-Token` before processing the incoming webhook update.
