### PR TITLE
⚠️ Separate `Bot.local` and default `Bot` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.27.3
+
+- ⚠️ Removed `baseURL` from `Bot` primary constructor. 
+- This is to rigidly separate `Bot.local` against `Bot` constructors.  Why do we need to keep two copies of the same thing?
+- From now on, local bots must be constructed using `Bot.local`.
+- If you weren't using the local bot API, this change won't affect you.
+
 # 1.27.2
 
 - Fix: Base URL wasn't even being considered. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Thanks to [@itsmhmd for reporting](https://t.me/televersedart/1668)
 - Updated Request URI construction logic
 - ⚠️ Breaking! Removed `APIScheme`. Now the scheme must be added to the `baseURL` itself.
+- If you weren't using the local bot API, this change won't affect you.
 
 # 1.27.1
 

--- a/lib/src/televerse/api/raw_api.dart
+++ b/lib/src/televerse/api/raw_api.dart
@@ -10,6 +10,9 @@ class RawAPI {
   /// Default base URL for the Telegram API.
   static const String defaultBase = "https://api.telegram.org";
 
+  /// Default local base URL
+  static const String defaultLocalBase = "http://localhost:8081";
+
   /// The Bot Token.
   final String token;
 
@@ -79,7 +82,7 @@ class RawAPI {
   /// When using `RawAPI.local`, the [baseUrl] is set to `localhost:8081` by default.
   factory RawAPI.local(
     String token, {
-    String baseUrl = "localhost:8081",
+    String baseUrl = RawAPI.defaultLocalBase,
     LoggerOptions? loggerOptions,
     Duration? timeout,
   }) {

--- a/lib/src/televerse/bot/bot.dart
+++ b/lib/src/televerse/bot/bot.dart
@@ -135,15 +135,8 @@ class Bot<CTX extends Context> {
     return str;
   }
 
-  /// Create a new bot instance.
-  ///
-  /// To create a new bot instance, you need to pass the bot token. You can also pass a [fetcher] to the constructor. The fetcher is used to fetch updates from the Telegram servers. By default, the bot uses long polling to fetch updates. You can also use webhooks to fetch updates.
-  ///
-  /// ## Using Local Bot API Server
-  /// You can use the [Bot] class to create a bot instance that listens to a local Bot API server. Use the [Bot.local] constructor to create a bot instance that listens to a local Bot API server.
-  ///
-  /// You can pass the [baseURL] parameter to the constructor to specify the base URL of the Telegram Bot API. By default, the base URL is `api.telegram.org`. This parameter will be used to create the [RawAPI] instance that points to your local Bot API server.
-  Bot(
+  /// Private Constructor!
+  Bot._(
     this.token, {
     Fetcher<CTX>? fetcher,
     String baseURL = RawAPI.defaultBase,
@@ -159,6 +152,26 @@ class Bot<CTX extends Context> {
         ) {
     // Set the default error handler
     onError(_defaultErrorHandler);
+  }
+
+  /// Create a new bot instance.
+  ///
+  /// To create a new bot instance, you need to pass the bot token. You can also pass a [fetcher] to the constructor. The fetcher is used to fetch updates from the Telegram servers. By default, the bot uses long polling to fetch updates. You can also use webhooks to fetch updates.
+  ///
+  /// ## Using Local Bot API Server
+  /// You can use the [Bot] class to create a bot instance that listens to a local Bot API server. Use the [Bot.local] constructor to create a bot instance that listens to a local Bot API server.
+  factory Bot(
+    String token, {
+    Fetcher<CTX>? fetcher,
+    LoggerOptions? loggerOptions,
+    Duration? timeout,
+  }) {
+    return Bot._(
+      token,
+      fetcher: fetcher,
+      loggerOptions: loggerOptions,
+      timeout: timeout,
+    );
   }
 
   /// Handles the error in initial `getMe` call
@@ -178,7 +191,7 @@ class Bot<CTX extends Context> {
   ///
   /// [token] - Bot token.
   ///
-  /// [baseURL] - Base URL of the Telegram Bot API. By default, the base URL is `localhost:8081`. This parameter will be used to create the [RawAPI] instance that points to your local Bot API server.
+  /// [baseURL] - Base URL of the Telegram Bot API. By default, the base URL is `http://localhost:8081`. This parameter will be used to create the [RawAPI] instance that points to your local Bot API server.
   ///
   /// [fetcher] - The fetcher - used to fetch updates from the Telegram servers. By default, the bot uses long polling to fetch updates. You can also use webhooks to fetch updates.
   ///
@@ -199,12 +212,12 @@ class Bot<CTX extends Context> {
   factory Bot.local(
     String token, {
     Fetcher<CTX>? fetcher,
-    String baseURL = "http://localhost:8081",
+    String baseURL = RawAPI.defaultLocalBase,
     LoggerOptions? loggerOptions,
     Duration? timeout,
   }) {
-    print('Using local Bot API server at $baseURL');
-    return Bot(
+    print('🌐 [Televerse] Using local Bot API server at $baseURL');
+    return Bot._(
       token,
       fetcher: fetcher,
       baseURL: baseURL,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.11!
-version: 1.27.2
+version: 1.27.3
 homepage: https://televerse.xooniverse.com
 repository: https://github.com/xooniverse/televerse
 topics:


### PR DESCRIPTION
- ⚠️ Removed `baseURL` from `Bot` primary constructor. 
- This is to rigidly separate `Bot.local` against `Bot` constructors.  Why do we need to keep two copies of the same thing?
- From now on, local bots must be constructed using `Bot.local`.
- If you weren't using the local bot API, this change won't affect you.