### PR TITLE
🤖 Bot API 8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.2.0
+
+- 🤖 Bot API 8.2
+- Added the methods `verifyUser`, `verifyChat`, `removeUserVerification`, and `removeChatVerification`, allowing bots to manage verifications on behalf of an organization.
+- Added the field `upgrade_star_count` to the class `Gift`.
+- Added the parameter `pay_for_upgrade` to the method `sendGift`.
+- Removed the field `hide_url` from the class `InlineQueryResultArticle`. Pass an empty string as `url` instead.
+
 # 2.1.1
 
 - Updated switch statements to Switch expressions.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Sreelal TS. All rights reserved.
+Copyright (c) 2020 Xooniverse. All rights reserved.
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Pub Version](https://img.shields.io/pub/v/televerse?color=blue&logo=blue)](https://pub.dev/packages/televerse)
 ![GitHub](https://img.shields.io/github/license/xooniverse/televerse?color=green)
-![](https://shields.io/badge/Latest-Bot%20API%208.1-blue)
+![](https://shields.io/badge/Latest-Bot%20API%208.2-blue)
 
   <a href="https://telegram.me/TeleverseDart">
     <img src="https://img.shields.io/badge/Telegram%2F@TeleverseDart-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white"/>
@@ -12,7 +12,7 @@
 
 ---
 
-🤖 `Bot API version: Bot API 8.1 (December 4, 2024)` 🎃
+🤖 `Bot API version: Bot API 8.2 (January 1, 2025)`
 
 Televerse is a powerful, easy-to-use, and highly customizable Telegram bot
 framework built with Dart programming language. It provides a complete and
@@ -24,11 +24,11 @@ public interface, making it easy for developers to write strictly typed code.
 
 ### 🤖 Bot API 8.1 🎃
 
-(🗓️ December 4, 2024)
+(🗓️ January 1, 2025)
 
-In a nutshell, Bots can now detect commissions and affiliate transactions!
+In a nutshell, Bots can now verify chats and users on behalf of an organization! Includes minor Gifts related changes as well.
 
-Checkout [changelog](https://core.telegram.org/bots/api-changelog#december-4-2024) for more
+Checkout [changelog](https://core.telegram.org/bots/api-changelog#january-1-2025) for more
 details! 🚀
 
 <hr>

--- a/lib/src/telegram/models/gift.dart
+++ b/lib/src/telegram/models/gift.dart
@@ -17,6 +17,9 @@ class Gift {
   /// Optional. The number of remaining gifts of this type that can be sent; for limited gifts only.
   final int? remainingCount;
 
+  /// Optional. The number of Telegram Stars that must be paid to upgrade the gift to a unique one.
+  final int? upgradeStarCount;
+
   /// Creates a [Gift] object.
   const Gift({
     required this.id,
@@ -24,6 +27,7 @@ class Gift {
     required this.starCount,
     this.totalCount,
     this.remainingCount,
+    this.upgradeStarCount,
   });
 
   /// Creates a [Gift] object from a JSON map.
@@ -34,6 +38,7 @@ class Gift {
       starCount: json['star_count'],
       totalCount: json['total_count'],
       remainingCount: json['remaining_count'],
+      upgradeStarCount: json['upgrade_star_count'],
     );
   }
 
@@ -45,6 +50,7 @@ class Gift {
       'star_count': starCount,
       'total_count': totalCount,
       'remaining_count': remainingCount,
-    };
+      'upgrade_star_count': upgradeStarCount,
+    }..removeWhere(_nullFilter);
   }
 }

--- a/lib/src/telegram/models/inline_query_result_article.dart
+++ b/lib/src/telegram/models/inline_query_result_article.dart
@@ -18,9 +18,6 @@ class InlineQueryResultArticle implements InlineQueryResult {
   /// Optional. URL of the result
   final String? url;
 
-  /// Optional. Pass True if you don't want the URL to be shown in the message
-  final bool? hideUrl;
-
   /// Optional. Short description of the result
   final String? description;
 
@@ -40,7 +37,6 @@ class InlineQueryResultArticle implements InlineQueryResult {
     required this.inputMessageContent,
     this.replyMarkup,
     this.url,
-    this.hideUrl,
     this.description,
     this.thumbnailUrl,
     this.thumbnailWidth,
@@ -57,7 +53,6 @@ class InlineQueryResultArticle implements InlineQueryResult {
       'input_message_content': inputMessageContent.toJson(),
       'reply_markup': replyMarkup?.toJson(),
       'url': url,
-      'hide_url': hideUrl,
       'description': description,
       'thumbnail_url': thumbnailUrl,
       'thumbnail_width': thumbnailWidth,
@@ -79,7 +74,6 @@ class InlineQueryResultArticle implements InlineQueryResult {
               json['reply_markup'] as Map<String, dynamic>,
             ),
       url: json['url'] as String?,
-      hideUrl: json['hide_url'] as bool?,
       description: json['description'] as String?,
       thumbnailUrl: json['thumbnail_url'] as String?,
       thumbnailWidth: json['thumbnail_width'] as int?,
@@ -108,7 +102,6 @@ class InlineQueryResultArticle implements InlineQueryResult {
       inputMessageContent: inputMessageContent ?? this.inputMessageContent,
       replyMarkup: replyMarkup ?? this.replyMarkup,
       url: url ?? this.url,
-      hideUrl: hideUrl ?? this.hideUrl,
       description: description ?? this.description,
       thumbnailUrl: thumbnailUrl ?? this.thumbnailUrl,
       thumbnailWidth: thumbnailWidth ?? this.thumbnailWidth,

--- a/lib/src/televerse/api/raw_api.dart
+++ b/lib/src/televerse/api/raw_api.dart
@@ -4229,12 +4229,15 @@ class RawAPI {
   ///   “bold”, “italic”, “underline”, “strikethrough”, “spoiler”, and “custom_emoji” are ignored.
   /// - [textEntities] (List<MessageEntity>, optional): A JSON-serialized list of special entities
   ///   that appear in the gift text. Can be specified instead of `textParseMode`.
+  /// - [payForUpgrade] - Pass True to pay for the gift upgrade from the bot's
+  /// balance, thereby making the upgrade free for the receiver
   Future<bool> sendGift({
     required int userId,
     required String giftId,
     String? text,
     ParseMode? textParseMode,
     List<MessageEntity>? textEntities,
+    bool? payForUpgrade,
   }) async {
     final params = {
       "user_id": userId,
@@ -4242,6 +4245,7 @@ class RawAPI {
       "text": text,
       "text_parse_mode": textParseMode?.value,
       "text_entities": textEntities?.map((e) => e.toJson()).toList(),
+      "pay_for_upgrade": payForUpgrade,
     };
 
     return await _makeApiBoolCall(

--- a/lib/src/televerse/api/raw_api.dart
+++ b/lib/src/televerse/api/raw_api.dart
@@ -4249,4 +4249,100 @@ class RawAPI {
       payload: Payload(params),
     );
   }
+
+  /// Verifies a user on behalf of the organization which is represented by
+  /// the bot. Returns True on success.
+  ///
+  /// Parameters:
+  /// - [userId] (int, required): Unique identifier of the target user.
+  /// - [customDescription] (String, optional): Custom description for
+  /// the verification; 0-70 characters. Must be empty if the organization
+  /// isn't allowed to provide a custom verification description.
+  Future<bool> verifyUser({
+    required int userId,
+    String? customDescription,
+  }) async {
+    final params = {
+      "user_id": userId,
+      "custom_description": customDescription,
+    };
+
+    final response = await _makeApiBoolCall(
+      APIMethod.verifyUser,
+      payload: Payload(params),
+    );
+
+    return response;
+  }
+
+  /// Verifies a chat on behalf of the organization which is represented by
+  /// the bot. Returns True on success.
+  ///
+  /// Parameters:
+  /// - [chatId] (ID, required): Unique identifier for the target chat or
+  /// username of the target channel (in the format @channelusername)
+  /// - [customDescription] (String, optional): Custom description for
+  /// the verification; 0-70 characters. Must be empty if the organization
+  /// isn't allowed to provide a custom verification description.
+  Future<bool> verifyChat({
+    required ID chatId,
+    String? customDescription,
+  }) async {
+    final params = {
+      "chat_id": chatId.id,
+      "custom_description": customDescription,
+    };
+
+    final response = await _makeApiBoolCall(
+      APIMethod.verifyChat,
+      payload: Payload(params),
+    );
+
+    return response;
+  }
+
+  /// Removes verification from a user who is currently verified on behalf
+  /// of the organization represented by the bot.
+  ///
+  /// Returns True on success.
+  ///
+  /// Parameters:
+  /// - [userId] - Unique identifier of the target user
+  Future<bool> removeUserVerification({
+    required int userId,
+  }) async {
+    final params = {
+      "user_id": userId,
+    };
+
+    final response = await _makeApiBoolCall(
+      APIMethod.removeUserVerification,
+      payload: Payload(params),
+    );
+
+    return response;
+  }
+
+  /// Removes verification from a chat that is currently verified on behalf of
+  /// the organization represented by the bot. Returns True on success.
+  ///
+  /// Returns True on success.
+  ///
+  /// Parameters:
+  /// - [chatId] - Unique identifier for the target chat or username of the
+  /// target channel (in the format @channelusername)
+  Future<bool> removeChatVerification({
+    required ID chatId,
+  }) async {
+    final params = {
+      "chat_id": chatId.id,
+    };
+
+    final response = await _makeApiBoolCall(
+      APIMethod.removeChatVerification,
+      payload: Payload(params),
+    );
+
+    return response;
+  }
 }

--- a/lib/src/televerse/builders/inline_query_result_builder.dart
+++ b/lib/src/televerse/builders/inline_query_result_builder.dart
@@ -29,7 +29,6 @@ class InlineQueryResultBuilder {
   /// - [contentGenerator] is a function that generates the content of the article.
   /// - [replyMarkup] is an optional inline keyboard attached to the message.
   /// - [url] is an optional URL of the result.
-  /// - [hideUrl] hides the URL in the message when set to true.
   /// - [description] is an optional short description of the result.
   /// - [thumbnailUrl] is an optional URL of the thumbnail for the result.
   /// - [thumbnailWidth] is the optional width of the thumbnail.
@@ -42,7 +41,6 @@ class InlineQueryResultBuilder {
     ) contentGenerator, {
     InlineKeyboardMarkup? replyMarkup,
     String? url,
-    bool? hideUrl,
     String? description,
     String? thumbnailUrl,
     int? thumbnailWidth,
@@ -57,7 +55,6 @@ class InlineQueryResultBuilder {
         ),
         replyMarkup: replyMarkup,
         url: url,
-        hideUrl: hideUrl,
         description: description,
         thumbnailHeight: thumbnailHeight,
         thumbnailUrl: thumbnailUrl,

--- a/lib/src/types/methods.dart
+++ b/lib/src/types/methods.dart
@@ -400,6 +400,20 @@ enum APIMethod {
 
   /// Sends a gift to the given user.
   sendGift._("sendGift"),
+
+  /// Verifies a user on behalf of the organization which is represented by the bot.
+  verifyUser._("verifyUser"),
+
+  /// Verifies a chat on behalf of the organization which is represented by the bot.
+  verifyChat._("verifyChat"),
+
+  /// Removes verification from a user who is currently verified on behalf of
+  /// the organization represented by the bot.
+  removeUserVerification._("removeUserVerification"),
+
+  /// Removes verification from a chat that is currently verified on behalf of
+  /// the organization represented by the bot.
+  removeChatVerification._("removeChatVerification"),
   ;
 
   /// The name of the method.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 8.1!
-version: 2.1.1
+version: 2.2.0
 homepage: https://televerse.xooniverse.com
 repository: https://github.com/xooniverse/televerse
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: televerse
-description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 8.1!
+description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 8.2!
 version: 2.2.0
 homepage: https://televerse.xooniverse.com
 repository: https://github.com/xooniverse/televerse


### PR DESCRIPTION
# 2.2.0

- 🤖 Bot API 8.2
- Added the methods `verifyUser`, `verifyChat`, `removeUserVerification`, and `removeChatVerification`, allowing bots to manage verifications on behalf of an organization.
- Added the field `upgrade_star_count` to the class `Gift`.
- Added the parameter `pay_for_upgrade` to the method `sendGift`.
- Removed the field `hide_url` from the class `InlineQueryResultArticle`. Pass an empty string as `url` instead.