### PR TITLE
fix: can't call bot.getMe() before bot.start()

### DIFF
--- a/lib/src/televerse/bot/bot.dart
+++ b/lib/src/televerse/bot/bot.dart
@@ -224,7 +224,9 @@ class Bot<CTX extends Context> {
         fetcher._updateStreamController?.isClosed == true) {
       fetcher._updateStreamController = StreamController<Update>.broadcast();
     }
+
     // Set instance variable
+    _initialized = true;
     _instance = this;
   }
 
@@ -233,11 +235,11 @@ class Bot<CTX extends Context> {
   /// In other words, initial getMe request :)
   Future<User>? _getMeRequest;
 
-  /// Whether _me is filled or not
-  _GetMeStatus _getMeStatus = _GetMeStatus.notInitiated;
+  /// Whether the bot has been  is filled or not
+  bool _initialized = false;
 
   /// Whether the `Bot.me` is filled
-  bool get initialized => _getMeStatus == _GetMeStatus.completed;
+  bool get initialized => _initialized;
 
   /// Information about the bot.
   User? _me;
@@ -267,11 +269,7 @@ class Bot<CTX extends Context> {
     try {
       if (_me != null) return _me!;
 
-      _getMeStatus = _GetMeStatus.pending;
-      _me = await api.getMe();
-      _getMeStatus = _GetMeStatus.completed;
-
-      return _me!;
+      return _me = await api.getMe();
     } catch (err, stack) {
       final exception = TeleverseException.getMeRequestFailed(err, stack);
       throw exception;

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -94,19 +94,6 @@ extension FromAndChatExt on Update {
   }
 }
 
-/// (Internal) Current status of the initial `Bot.getMe` call
-enum _GetMeStatus {
-  /// Completed
-  completed,
-
-  /// Pending
-  pending,
-
-  /// Not Initiated
-  notInitiated,
-  ;
-}
-
 /// Extension on `Chat` to create ID of the chat
 extension GetChatID on Chat {
   /// Returns the `ChatID` of the chat.


### PR DESCRIPTION
When calling bot.getMe() before start, the bot.init() function didn't actually initialize anything.