### PR TITLE
fix the class usage example

### DIFF
--- a/lib/src/televerse/markups/inline_keyboard.dart
+++ b/lib/src/televerse/markups/inline_keyboard.dart
@@ -16,9 +16,9 @@ part 'inline_keyboard.g.dart';
 /// ```dart
 /// // Create a new inline keyboard.
 /// var keyboard = InlineKeyboard()
-///   ..addUrl("Open Google", "https://google.com")
-///   ..row()
-///   ..add("Send a callback query", "callback_query");
+///   .addUrl("Open Google", "https://google.com")
+///   .row()
+///   .add("Send a callback query", "callback_query");
 ///
 /// // Send the keyboard with the message "Hello World!".
 /// ctx.api.sendMessage(ctx.id, "Hello World!", replyMarkup: keyboard);


### PR DESCRIPTION
The current approach creates a new instance of the InlineKeyboard class for every call. As a result, the example code provided would return an empty keyboard.